### PR TITLE
feat(db): Database Change - Users and Instructors

### DIFF
--- a/packages/postgres/src/entities/index.ts
+++ b/packages/postgres/src/entities/index.ts
@@ -1,6 +1,7 @@
 import { BaseEntity } from './base.entity';
+import { Instructor } from './instructor.entity';
 import { User } from './user.entity';
 
-export const entities = [BaseEntity, User];
+export const entities = [BaseEntity, Instructor, User];
 
-export { BaseEntity, User };
+export { BaseEntity, Instructor, User };

--- a/packages/postgres/src/entities/instructor.entity.ts
+++ b/packages/postgres/src/entities/instructor.entity.ts
@@ -1,4 +1,12 @@
-import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  UpdateDateColumn,
+} from 'typeorm';
 import { User } from './user.entity';
 
 /**
@@ -47,32 +55,32 @@ export class Instructor {
   public rating: number | null;
 
   /**
-   * COLUMN-DESCRIPTION: Timestamp when the instructor record was created
+   * COLUMN-DESCRIPTION: Timestamp when the instructor record was created (automatically managed by TypeORM)
    */
-  @Column({
+  @CreateDateColumn({
     type: 'timestamptz',
-    default: () => 'now()',
+    default: () => 'CURRENT_TIMESTAMP(6)',
     name: 'created_at',
   })
   public createdAt: Date;
 
   /**
-   * COLUMN-DESCRIPTION: Timestamp when the instructor record was last updated
+   * COLUMN-DESCRIPTION: Timestamp when the instructor record was last updated (automatically managed by TypeORM)
    */
-  @Column({
+  @UpdateDateColumn({
     type: 'timestamptz',
-    default: () => 'now()',
+    default: () => 'CURRENT_TIMESTAMP(6)',
+    onUpdate: 'CURRENT_TIMESTAMP(6)',
     name: 'updated_at',
   })
   public updatedAt: Date;
 
   /**
-   * COLUMN-DESCRIPTION: Timestamp for soft delete functionality, null if not deleted
+   * COLUMN-DESCRIPTION: Timestamp for soft delete functionality, null if not deleted (automatically managed by TypeORM)
    */
-  @Column({
+  @DeleteDateColumn({
     type: 'timestamptz',
-    nullable: true,
-    default: null,
+    default: () => 'null',
     name: 'deleted_at',
   })
   public deletedAt: Date | null;

--- a/packages/postgres/src/entities/instructor.entity.ts
+++ b/packages/postgres/src/entities/instructor.entity.ts
@@ -1,0 +1,86 @@
+import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import { User } from './user.entity';
+
+/**
+ * TABLE-NAME: instructors
+ * TABLE-DESCRIPTION: Stores instructor-specific details and statistics. The existence of a record in this table implicitly grants Instructor privileges to the associated user.
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - user_id is the primary key and foreign key to users.id (one-to-one relationship)
+ *   - rating must be between 0.00 and 9.99 (enforced by NUMERIC(3,2))
+ *   - bio and rating are optional fields
+ * TABLE-RELATIONSHIPS:
+ *   - One-to-one relationship with users table (required)
+ *   - user_id CASCADE delete: deleting a user will delete their instructor record
+ */
+@Entity('instructors')
+export class Instructor {
+  /**
+   * COLUMN-DESCRIPTION: Primary key and foreign key to users table, establishing one-to-one relationship
+   */
+  @Column({
+    type: 'uuid',
+    primary: true,
+    name: 'user_id',
+  })
+  public userId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Biography or description of the instructor, stored as text for unlimited length
+   */
+  @Column({
+    type: 'text',
+    nullable: true,
+    name: 'bio',
+  })
+  public bio: string | null;
+
+  /**
+   * COLUMN-DESCRIPTION: Instructor rating from 0.00 to 9.99, stored as NUMERIC(3,2) for precision
+   */
+  @Column({
+    type: 'numeric',
+    precision: 3,
+    scale: 2,
+    nullable: true,
+    name: 'rating',
+  })
+  public rating: number | null;
+
+  /**
+   * COLUMN-DESCRIPTION: Timestamp when the instructor record was created
+   */
+  @Column({
+    type: 'timestamptz',
+    default: () => 'now()',
+    name: 'created_at',
+  })
+  public createdAt: Date;
+
+  /**
+   * COLUMN-DESCRIPTION: Timestamp when the instructor record was last updated
+   */
+  @Column({
+    type: 'timestamptz',
+    default: () => 'now()',
+    name: 'updated_at',
+  })
+  public updatedAt: Date;
+
+  /**
+   * COLUMN-DESCRIPTION: Timestamp for soft delete functionality, null if not deleted
+   */
+  @Column({
+    type: 'timestamptz',
+    nullable: true,
+    default: null,
+    name: 'deleted_at',
+  })
+  public deletedAt: Date | null;
+
+  /**
+   * COLUMN-DESCRIPTION: One-to-one relationship to the user entity, CASCADE delete on user deletion
+   */
+  @OneToOne(() => User, (user) => user.instructor, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  public user: User;
+}

--- a/packages/postgres/src/entities/user.entity.ts
+++ b/packages/postgres/src/entities/user.entity.ts
@@ -1,28 +1,30 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, OneToOne } from 'typeorm';
 import { BaseEntity } from './base.entity';
+import { Instructor } from './instructor.entity';
 
 /**
  * TABLE-NAME: users
- * TABLE-DESCRIPTION: Stores user authentication credentials and basic user information
+ * TABLE-DESCRIPTION: Stores user authentication credentials and basic user information. Access control is implicit based on the existence of an associated instructors record.
  * TABLE-IMPORTANT-CONSTRAINTS:
- *   - username must be unique across all users
+ *   - email must be unique across all users
  *   - password is excluded from default queries (select: false)
  *   - inherits id (UUID), createdAt, and updatedAt from BaseEntity
  * TABLE-RELATIONSHIPS:
+ *   - One-to-one relationship with instructors table (optional)
  *   - Base entity for user-related entities (children, activities, etc.)
  */
 @Entity('users')
 export class User extends BaseEntity {
   /**
-   * COLUMN-DESCRIPTION: Unique username for user authentication, maximum 255 characters
+   * COLUMN-DESCRIPTION: Unique email address for user authentication, maximum 255 characters
    */
   @Column({
     type: 'varchar',
     length: 255,
     unique: true,
-    name: 'username',
+    name: 'email',
   })
-  public username: string;
+  public email: string;
 
   /**
    * COLUMN-DESCRIPTION: Hashed password for user authentication, excluded from default queries for security
@@ -34,4 +36,13 @@ export class User extends BaseEntity {
     select: false,
   })
   public password: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Optional one-to-one relationship with instructor profile. If present, user has instructor privileges.
+   */
+  @OneToOne(() => Instructor, (instructor) => instructor.user, {
+    cascade: false,
+    eager: false,
+  })
+  public instructor?: Instructor;
 }

--- a/packages/postgres/src/migrations/1762002883763-users-instructors-changes.ts
+++ b/packages/postgres/src/migrations/1762002883763-users-instructors-changes.ts
@@ -1,0 +1,94 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+/**
+ * Migration: UsersInstructorsChanges
+ *
+ * Changes:
+ * 1. Rename 'username' column to 'email' in the users table
+ * 2. Create instructors table with:
+ *    - user_id (UUID, PK, FK to users.id)
+ *    - bio (TEXT)
+ *    - rating (NUMERIC(3,2))
+ *
+ * This migration modifies the users table to use email instead of username
+ * and creates the instructors table for instructor-specific data.
+ * Note: instructors table uses user_id as primary key (one-to-one with users)
+ */
+export class UsersInstructorsChanges1762002883763
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Step 1: Rename username column to email in users table
+    await queryRunner.renameColumn('users', 'username', 'email');
+
+    // Step 2: Create instructors table with user_id as primary key
+    await queryRunner.createTable(
+      new Table({
+        name: 'instructors',
+        columns: [
+          {
+            name: 'user_id',
+            type: 'uuid',
+            isPrimary: true,
+            isNullable: false,
+          },
+          {
+            name: 'bio',
+            type: 'text',
+            isNullable: true,
+            default: null,
+          },
+          {
+            name: 'rating',
+            type: 'numeric',
+            precision: 3,
+            scale: 2,
+            isNullable: true,
+            default: null,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'deleted_at',
+            type: 'timestamptz',
+            isNullable: true,
+            default: null,
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Step 3: Create foreign key from instructors.user_id to users.id
+    await queryRunner.createForeignKey(
+      'instructors',
+      new TableForeignKey({
+        columnNames: ['user_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Step 1: Drop instructors table (FK will be dropped automatically)
+    await queryRunner.dropTable('instructors');
+
+    // Step 2: Rename email column back to username in users table
+    await queryRunner.renameColumn('users', 'email', 'username');
+  }
+}


### PR DESCRIPTION
## 📋 Description

This PR implements database schema changes for users and instructors tables as specified in issue #1.

## 🔧 Changes Made

### Migration (`1762002883763-users-instructors-changes.ts`)
1. **Renamed** `username` column to `email` in the `users` table
2. **Created** `instructors` table with:
   - `user_id` (UUID, Primary Key, Foreign Key to users.id)
   - `bio` (TEXT, nullable)
   - `rating` (NUMERIC(3,2), nullable)
   - Standard timestamp fields (created_at, updated_at, deleted_at)
   - CASCADE delete on user deletion

### Entity Updates
1. **Updated** `User` entity:
   - Changed `username` property to `email`
   - Added one-to-one relationship with `Instructor` entity
   - Updated documentation to reflect access control changes

2. **Created** `Instructor` entity:
   - Proper TypeORM decorators and column mappings
   - One-to-one relationship with `User` entity
   - Complete documentation following project standards

## ✅ Testing

- ✅ Migration tested with 2 complete up/down cycles
- ✅ TypeScript builds successfully without errors
- ✅ ESLint passes with no warnings
- ✅ All entities properly exported
- ✅ No use of `any` types (general rule compliance)

## 📝 Implementation Checklist

All subtasks from `.cursor/rules/@task-change-postgres.md` have been completed:

- [x] SUBTASK-01: Create a new feature branch from main
- [x] SUBTASK-02: Validate inputs and prepare workspace
- [x] SUBTASK-03: Review previous migrations for conflicts
- [x] SUBTASK-04: Create a migration file
- [x] SUBTASK-05: Implement up and down methods
- [x] SUBTASK-06: Test run and revert twice
- [x] SUBTASK-07: Create or update enums in @repo/enums (N/A - no enums needed)
- [x] SUBTASK-08: Update entities under packages/postgres/src/entities
- [x] SUBTASK-09: Ensure entity documentation is up-to-date
- [x] SUBTASK-10: Verify TypeScript builds and lints
- [x] SUBTASK-11: Final readiness check
- [x] SUBTASK-12: General rule compliance
- [x] SUBTASK-13: Create a Pull Request

## 📚 Documentation

All entities include comprehensive documentation:
- Table-level documentation with purpose, constraints, and relationships
- Column-level documentation for each field
- JSDoc comments following project standards

## 🔗 Related Issue

Closes #1

## ⚠️ Breaking Changes

This migration renames the `username` column to `email` in the users table. Any code that references `username` will need to be updated.

---

**Note:** This PR strictly follows the monorepo conventions and standards defined in the Cursor rules. All changes are reversible through the migration's `down` method.