### PR TITLE
feat(postgres): Add instructors table with user relationship

### DIFF
--- a/packages/postgres/src/entities/index.ts
+++ b/packages/postgres/src/entities/index.ts
@@ -1,6 +1,7 @@
 import { BaseEntity } from './base.entity';
+import { Instructor } from './instructor.entity';
 import { User } from './user.entity';
 
-export const entities = [BaseEntity, User];
+export const entities = [BaseEntity, Instructor, User];
 
-export { BaseEntity, User };
+export { BaseEntity, Instructor, User };

--- a/packages/postgres/src/entities/instructor.entity.ts
+++ b/packages/postgres/src/entities/instructor.entity.ts
@@ -1,0 +1,56 @@
+import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { User } from './user.entity';
+
+/**
+ * TABLE-NAME: instructors
+ * TABLE-DESCRIPTION: Stores instructor-specific details and statistics for users with instructor privileges. The existence of a record in this table implicitly grants instructor role to the associated user.
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - user_id must be unique (one user can have only one instructor record)
+ *   - user_id is a foreign key to users table with CASCADE delete
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - One-to-one relationship with User (user_id references users.id)
+ */
+@Entity('instructors')
+export class Instructor extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the user ID, unique constraint ensures one instructor record per user
+   */
+  @Column({
+    type: 'uuid',
+    name: 'user_id',
+    unique: true,
+    nullable: false,
+  })
+  public userId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Biographical information about the instructor, can be null
+   */
+  @Column({
+    type: 'text',
+    name: 'bio',
+    nullable: true,
+  })
+  public bio: string | null;
+
+  /**
+   * COLUMN-DESCRIPTION: Instructor rating on a scale with precision 3 and scale 2 (e.g., 4.50), can be null
+   */
+  @Column({
+    type: 'numeric',
+    precision: 3,
+    scale: 2,
+    name: 'rating',
+    nullable: true,
+  })
+  public rating: number | null;
+
+  /**
+   * RELATIONSHIP: One-to-one relationship with User entity
+   */
+  @OneToOne(() => User, (user) => user.instructor, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  public user: User;
+}

--- a/packages/postgres/src/entities/user.entity.ts
+++ b/packages/postgres/src/entities/user.entity.ts
@@ -1,5 +1,6 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, OneToOne } from 'typeorm';
 import { BaseEntity } from './base.entity';
+import { Instructor } from './instructor.entity';
 
 /**
  * TABLE-NAME: users
@@ -9,7 +10,7 @@ import { BaseEntity } from './base.entity';
  *   - password is excluded from default queries (select: false)
  *   - inherits id (UUID), createdAt, and updatedAt from BaseEntity
  * TABLE-RELATIONSHIPS:
- *   - Base entity for user-related entities (children, activities, etc.)
+ *   - One-to-one relationship with Instructor (optional, when user has instructor privileges)
  */
 @Entity('users')
 export class User extends BaseEntity {
@@ -34,4 +35,10 @@ export class User extends BaseEntity {
     select: false,
   })
   public password: string;
+
+  /**
+   * RELATIONSHIP: One-to-one relationship with Instructor entity (inverse side)
+   */
+  @OneToOne(() => Instructor, (instructor) => instructor.user)
+  public instructor?: Instructor;
 }

--- a/packages/postgres/src/migrations/1762066299264-create-instructors-table.ts
+++ b/packages/postgres/src/migrations/1762066299264-create-instructors-table.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import {
+  DatabaseCreateTable,
+  DatabaseCreateForeignKey,
+  DatabaseDropForeignKey,
+} from './utils';
+
+export class CreateInstructorsTable1762066299264 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create instructors table
+    await DatabaseCreateTable(queryRunner, 'instructors', [
+      {
+        name: 'user_id',
+        type: 'uuid',
+        isNullable: false,
+        isUnique: true,
+      },
+      {
+        name: 'bio',
+        type: 'text',
+        isNullable: true,
+      },
+      {
+        name: 'rating',
+        type: 'numeric',
+        precision: 3,
+        scale: 2,
+        isNullable: true,
+      },
+    ]);
+
+    // Create foreign key relationship to users table
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'instructors',
+      'users',
+      'user_id',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop foreign key before dropping table
+    await DatabaseDropForeignKey(
+      queryRunner,
+      'instructors',
+      'users',
+      'user_id',
+    );
+
+    // Drop instructors table
+    await queryRunner.dropTable('instructors');
+  }
+}


### PR DESCRIPTION
## Description

Implements database schema changes for issue #4: Add `instructors` table with one-to-one relationship to `users` table. This enables implicit instructor role assignment based on the existence of an instructor record.

## Changes Made

### Migration
- Created migration `1762066299264-create-instructors-table.ts`
- Added `instructors` table with:
  - `id` (UUID, Primary Key)
  - `user_id` (UUID, Foreign Key to users.id, unique)
  - `bio` (TEXT, nullable)
  - `rating` (NUMERIC(3,2), nullable)
  - Standard timestamps (created_at, updated_at, deleted_at)
- Foreign key constraint with CASCADE delete to users table

### Entities
- Created `Instructor` entity with full documentation
- Updated `User` entity with one-to-one relationship to Instructor
- Updated entity exports in `packages/postgres/src/entities/index.ts`

### Testing
- ✅ Migration tested: run and revert cycles completed successfully (2 cycles)
- ✅ TypeScript compilation verified
- ✅ Linting passed
- ✅ Final migration state confirmed

## Subtask Completion Checklist

- [x] SUBTASK-00: Description and requirement reviewed
- [x] SUBTASK-01: Created feature branch `feature/db-change-add-users-and-instructors-tables`
- [x] SUBTASK-02: Validated inputs and prepared workspace
- [x] SUBTASK-03: Read and followed `@postgres.md` rules
- [x] SUBTASK-04: Reviewed previous migrations (users table already exists)
- [x] SUBTASK-05: Created migration file
- [x] SUBTASK-06: Implemented up and down methods with helper utilities
- [x] SUBTASK-07: Tested run and revert twice successfully
- [x] SUBTASK-08: No enum fields required (N/A)
- [x] SUBTASK-09: Created Instructor entity and updated User entity
- [x] SUBTASK-10: Added comprehensive entity documentation
- [x] SUBTASK-11: Verified TypeScript builds and lints successfully
- [x] SUBTASK-12: Final readiness check passed
- [x] SUBTASK-13: General rule compliance verified (no `any` types)
- [x] SUBTASK-14: Created this pull request

## Database Schema

### instructors Table
- **Purpose**: Stores instructor-specific details and statistics. The existence of a record implicitly grants instructor privileges to the associated user.
- **Key Fields**:
  - `user_id` (Foreign Key referencing `users.id`, unique): UUID
  - `bio`: TEXT (nullable)
  - `rating`: NUMERIC(3, 2) (nullable, e.g., 4.50)

### Relationship
- One-to-one relationship between `users` and `instructors`
- CASCADE delete: removing a user automatically removes their instructor record

## Closes

Closes #4