### PR TITLE
feat(db): Database Change - courses + sections + lessons

### DIFF
--- a/packages/enums/src/courses-status.enum.ts
+++ b/packages/enums/src/courses-status.enum.ts
@@ -1,0 +1,31 @@
+/**
+ * CoursesStatusEnum
+ *
+ * Represents the possible status values for a course in the courses table.
+ */
+export enum CoursesStatusEnum {
+  /**
+   * DRAFT - Course is being created and is not yet ready for review
+   */
+  DRAFT = 'Draft',
+
+  /**
+   * REVIEW - Course is submitted for review by administrators
+   */
+  REVIEW = 'Review',
+
+  /**
+   * PUBLISHED - Course is approved and publicly available to students
+   */
+  PUBLISHED = 'Published',
+
+  /**
+   * ARCHIVED - Course is no longer actively offered but remains visible
+   */
+  ARCHIVED = 'Archived',
+
+  /**
+   * DELETED - Course is marked for deletion (soft delete)
+   */
+  DELETED = 'Deleted',
+}

--- a/packages/enums/src/index.ts
+++ b/packages/enums/src/index.ts
@@ -1,1 +1,2 @@
+export { CoursesStatusEnum } from './courses-status.enum';
 export { SortEnum } from './sort.enum';

--- a/packages/postgres/src/entities/course.entity.ts
+++ b/packages/postgres/src/entities/course.entity.ts
@@ -1,0 +1,78 @@
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { CoursesStatusEnum } from '@repo/enums';
+import { BaseEntity } from './base.entity';
+import { Instructor } from './instructor.entity';
+import { Section } from './section.entity';
+
+/**
+ * TABLE-NAME: courses
+ * TABLE-DESCRIPTION: Stores main catalog of available courses. All courses are free.
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - instructor_id must reference a valid instructor (foreign key to instructors.id)
+ *   - status must be one of the CoursesStatusEnum values
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with Instructor (instructor_id references instructors.id)
+ *   - One-to-many relationship with Section (sections reference this course)
+ */
+@Entity('courses')
+export class Course extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the instructor who created this course
+   */
+  @Column({
+    type: 'uuid',
+    name: 'instructor_id',
+    nullable: false,
+  })
+  public instructorId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Title of the course, required field with max length 255 characters
+   */
+  @Column({
+    type: 'varchar',
+    length: 255,
+    name: 'title',
+    nullable: false,
+  })
+  public title: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Detailed description of the course content, can be null
+   */
+  @Column({
+    type: 'text',
+    name: 'description',
+    nullable: true,
+  })
+  public description: string | null;
+
+  /**
+   * COLUMN-DESCRIPTION: Current status of the course (Draft, Review, Published, Archived, Deleted), defaults to Draft
+   */
+  @Column({
+    type: 'enum',
+    name: 'status',
+    enum: CoursesStatusEnum,
+    default: CoursesStatusEnum.DRAFT,
+    nullable: false,
+  })
+  public status: CoursesStatusEnum;
+
+  /**
+   * RELATIONSHIP: Many-to-one relationship with Instructor entity
+   */
+  @ManyToOne(() => Instructor, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'instructor_id' })
+  public instructor: Instructor;
+
+  /**
+   * RELATIONSHIP: One-to-many relationship with Section entity
+   */
+  @OneToMany(() => Section, (section) => section.course, {
+    cascade: false,
+    eager: false,
+  })
+  public sections: Section[];
+}

--- a/packages/postgres/src/entities/index.ts
+++ b/packages/postgres/src/entities/index.ts
@@ -1,7 +1,10 @@
 import { BaseEntity } from './base.entity';
+import { Course } from './course.entity';
 import { Instructor } from './instructor.entity';
+import { Lesson } from './lesson.entity';
+import { Section } from './section.entity';
 import { User } from './user.entity';
 
-export const entities = [BaseEntity, Instructor, User];
+export const entities = [BaseEntity, Course, Instructor, Lesson, Section, User];
 
-export { BaseEntity, Instructor, User };
+export { BaseEntity, Course, Instructor, Lesson, Section, User };

--- a/packages/postgres/src/entities/lesson.entity.ts
+++ b/packages/postgres/src/entities/lesson.entity.ts
@@ -1,0 +1,55 @@
+import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { Section } from './section.entity';
+
+/**
+ * TABLE-NAME: lessons
+ * TABLE-DESCRIPTION: Individual learning content unit (video, quiz, article) within a section
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - section_id must reference a valid section (foreign key to sections.id)
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with Section (section_id references sections.id)
+ */
+@Entity('lessons')
+export class Lesson extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the section this lesson belongs to
+   */
+  @Column({
+    type: 'uuid',
+    name: 'section_id',
+    nullable: false,
+  })
+  public sectionId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Title of the lesson, required field with max length 255 characters
+   */
+  @Column({
+    type: 'varchar',
+    length: 255,
+    name: 'title',
+    nullable: false,
+  })
+  public title: string;
+
+  /**
+   * COLUMN-DESCRIPTION: URL to the lesson content (video, article, etc.), can be null
+   */
+  @Column({
+    type: 'text',
+    name: 'content_url',
+    nullable: true,
+  })
+  public contentUrl: string | null;
+
+  /**
+   * RELATIONSHIP: Many-to-one relationship with Section entity
+   */
+  @ManyToOne(() => Section, (section) => section.lessons, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'section_id' })
+  public section: Section;
+}

--- a/packages/postgres/src/entities/section.entity.ts
+++ b/packages/postgres/src/entities/section.entity.ts
@@ -1,0 +1,65 @@
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
+import { BaseEntity } from './base.entity';
+import { Course } from './course.entity';
+import { Lesson } from './lesson.entity';
+
+/**
+ * TABLE-NAME: sections
+ * TABLE-DESCRIPTION: Logical grouping of lessons within a course, organized in a specific order
+ * TABLE-IMPORTANT-CONSTRAINTS:
+ *   - course_id must reference a valid course (foreign key to courses.id)
+ *   - order_index defines the sequence of sections within a course
+ *   - inherits id (UUID), createdAt, updatedAt, and deletedAt from BaseEntity
+ * TABLE-RELATIONSHIPS:
+ *   - Many-to-one relationship with Course (course_id references courses.id)
+ *   - One-to-many relationship with Lesson (lessons reference this section)
+ */
+@Entity('sections')
+export class Section extends BaseEntity {
+  /**
+   * COLUMN-DESCRIPTION: Foreign key referencing the course this section belongs to
+   */
+  @Column({
+    type: 'uuid',
+    name: 'course_id',
+    nullable: false,
+  })
+  public courseId: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Title of the section, required field with max length 255 characters
+   */
+  @Column({
+    type: 'varchar',
+    length: 255,
+    name: 'title',
+    nullable: false,
+  })
+  public title: string;
+
+  /**
+   * COLUMN-DESCRIPTION: Order index for section sequence within the course, required field
+   */
+  @Column({
+    type: 'integer',
+    name: 'order_index',
+    nullable: false,
+  })
+  public orderIndex: number;
+
+  /**
+   * RELATIONSHIP: Many-to-one relationship with Course entity
+   */
+  @ManyToOne(() => Course, (course) => course.sections, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'course_id' })
+  public course: Course;
+
+  /**
+   * RELATIONSHIP: One-to-many relationship with Lesson entity
+   */
+  @OneToMany(() => Lesson, (lesson) => lesson.section, {
+    cascade: false,
+    eager: false,
+  })
+  public lessons: Lesson[];
+}

--- a/packages/postgres/src/migrations/1762068074743-create-courses-sections-lessons-tables.ts
+++ b/packages/postgres/src/migrations/1762068074743-create-courses-sections-lessons-tables.ts
@@ -1,0 +1,130 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import {
+  DatabaseCreateTable,
+  DatabaseCreateForeignKey,
+  DatabaseDropForeignKey,
+} from './utils';
+
+export class CreateCoursesSectionsLessonsTables1762068074743
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create courses table
+    await DatabaseCreateTable(queryRunner, 'courses', [
+      {
+        name: 'instructor_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'title',
+        type: 'varchar',
+        length: '255',
+        isNullable: false,
+      },
+      {
+        name: 'description',
+        type: 'text',
+        isNullable: true,
+      },
+      {
+        name: 'status',
+        type: 'enum',
+        enum: ['Draft', 'Review', 'Published', 'Archived', 'Deleted'],
+        isNullable: false,
+        default: "'Draft'",
+      },
+    ]);
+
+    // Create foreign key from courses to instructors (via user_id)
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'courses',
+      'instructors',
+      'instructor_id',
+    );
+
+    // Create sections table
+    await DatabaseCreateTable(queryRunner, 'sections', [
+      {
+        name: 'course_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'title',
+        type: 'varchar',
+        length: '255',
+        isNullable: false,
+      },
+      {
+        name: 'order_index',
+        type: 'integer',
+        isNullable: false,
+      },
+    ]);
+
+    // Create foreign key from sections to courses
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'sections',
+      'courses',
+      'course_id',
+    );
+
+    // Create lessons table
+    await DatabaseCreateTable(queryRunner, 'lessons', [
+      {
+        name: 'section_id',
+        type: 'uuid',
+        isNullable: false,
+      },
+      {
+        name: 'title',
+        type: 'varchar',
+        length: '255',
+        isNullable: false,
+      },
+      {
+        name: 'content_url',
+        type: 'text',
+        isNullable: true,
+      },
+    ]);
+
+    // Create foreign key from lessons to sections
+    await DatabaseCreateForeignKey(
+      queryRunner,
+      'lessons',
+      'sections',
+      'section_id',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop foreign keys first (in reverse order)
+    await DatabaseDropForeignKey(
+      queryRunner,
+      'lessons',
+      'sections',
+      'section_id',
+    );
+    await DatabaseDropForeignKey(
+      queryRunner,
+      'sections',
+      'courses',
+      'course_id',
+    );
+    await DatabaseDropForeignKey(
+      queryRunner,
+      'courses',
+      'instructors',
+      'instructor_id',
+    );
+
+    // Drop tables (in reverse order of creation)
+    await queryRunner.dropTable('lessons');
+    await queryRunner.dropTable('sections');
+    await queryRunner.dropTable('courses');
+  }
+}


### PR DESCRIPTION
## Description

This PR implements database schema changes for courses, sections, and lessons tables as defined in issue #6.

## Changes Made

### Database Migration
- ✅ Created migration `1762068074743-create-courses-sections-lessons-tables.ts`
- ✅ Implemented reversible `up` and `down` methods
- ✅ Tested migration run and revert twice successfully

### Enums
- ✅ Created `CoursesStatusEnum` with values:
  - `Draft` (default)
  - `Review`
  - `Published`
  - `Archived`
  - `Deleted`

### Entities
- ✅ **Course Entity** (`courses` table)
  - `instructor_id` (FK to `instructors.id`)
  - `title` (VARCHAR 255, required)
  - `description` (TEXT, nullable)
  - `status` (enum, defaults to Draft)
  - Many-to-one relationship with Instructor
  - One-to-many relationship with Section

- ✅ **Section Entity** (`sections` table)
  - `course_id` (FK to `courses.id`)
  - `title` (VARCHAR 255, required)
  - `order_index` (INTEGER, required)
  - Many-to-one relationship with Course
  - One-to-many relationship with Lesson

- ✅ **Lesson Entity** (`lessons` table)
  - `section_id` (FK to `sections.id`)
  - `title` (VARCHAR 255, required)
  - `content_url` (TEXT, nullable)
  - Many-to-one relationship with Section

### Documentation
- ✅ All entities include comprehensive TABLE-DOCUMENT and COLUMN-DOCUMENT comments
- ✅ Relationships properly documented

### Testing & Validation
- ✅ TypeScript builds successfully for both `@repo/enums` and `@repo/postgres`
- ✅ No linter errors
- ✅ Migration tested with run/revert cycles (2x)
- ✅ All foreign keys configured with CASCADE delete

## Checklist

All subtasks from `.cursor/rules/@task-change-postgres.md` have been completed:

- [x] SUBTASK-01: Create a new feature branch from main
- [x] SUBTASK-02: Validate inputs and prepare workspace
- [x] SUBTASK-03: Read Postgres Rules
- [x] SUBTASK-04: Review previous migrations for conflicts
- [x] SUBTASK-05: Create a migration file
- [x] SUBTASK-06: Implement up and down methods
- [x] SUBTASK-07: Test run and revert twice
- [x] SUBTASK-08: Create or update enums in @repo/enums
- [x] SUBTASK-09: Update entities under packages/postgres/src/entities
- [x] SUBTASK-10: Ensure entity documentation is up-to-date
- [x] SUBTASK-11: Verify TypeScript builds and lints
- [x] SUBTASK-12: Final readiness check
- [x] SUBTASK-13: General Rule Compliance
- [x] SUBTASK-14: Create a Pull Request

## Database Schema

```sql
-- courses table
CREATE TABLE courses (
  id UUID PRIMARY KEY,
  instructor_id UUID NOT NULL REFERENCES instructors(id) ON DELETE CASCADE,
  title VARCHAR(255) NOT NULL,
  description TEXT,
  status courses_status_enum NOT NULL DEFAULT 'Draft',
  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  deleted_at TIMESTAMPTZ
);

-- sections table
CREATE TABLE sections (
  id UUID PRIMARY KEY,
  course_id UUID NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
  title VARCHAR(255) NOT NULL,
  order_index INTEGER NOT NULL,
  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  deleted_at TIMESTAMPTZ
);

-- lessons table
CREATE TABLE lessons (
  id UUID PRIMARY KEY,
  section_id UUID NOT NULL REFERENCES sections(id) ON DELETE CASCADE,
  title VARCHAR(255) NOT NULL,
  content_url TEXT,
  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  deleted_at TIMESTAMPTZ
);
```

Closes #6